### PR TITLE
[HOPSWORKS-603] Make mmlspark available to all (py)spark apps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/Azure/mmlspark -->
+    <dependency>
+      <groupId>Azure</groupId>
+      <artifactId>mmlspark</artifactId>
+      <version>0.13</version>
+    </dependency>
     <dependency>
       <groupId>io.hops</groupId>
       <artifactId>hadoop-common</artifactId>


### PR DESCRIPTION
By including mmlspark in hops-util, we make it much easier to use. This outweighs flexibility of users being able to pick their version. It's a small library - 2.2MB, so won't add that much to the resource localization.

https://hopshadoop.atlassian.net/browse/HOPSWORKS-603